### PR TITLE
added setText method

### DIFF
--- a/AEOTPTextField/Source/UIKit/Core/AEOTPTextField.swift
+++ b/AEOTPTextField/Source/UIKit/Core/AEOTPTextField.swift
@@ -75,6 +75,15 @@ public class AEOTPTextField: UITextField {
             currentLabel.backgroundColor = otpBackgroundColor
         }
     }
+    /// Use this func to set the text in the code
+    public func setText(_ text: String) {
+        let characters = Array(text)
+        for i in 0 ..< characters.count {
+            if digitLabels.indices.contains(i) {
+                digitLabels[i].text = String(characters[i])
+            }
+        }
+    }
 }
 
 // MARK: - PRIVATE METHODS


### PR DESCRIPTION
Added a method so developers can set the text themselves in the code, 
Example Use:
When you wanna use the OTOPTextField just to show something not as a user interactive text field.