### PR TITLE
fix: Force Left to Right direction issue

### DIFF
--- a/AEOTPTextField/Source/UIKit/Core/AEOTPTextField.swift
+++ b/AEOTPTextField/Source/UIKit/Core/AEOTPTextField.swift
@@ -106,6 +106,7 @@ private extension AEOTPTextField {
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fillEqually
+        stackView.semanticContentAttribute = self.semanticContentAttribute
         stackView.spacing = 8
         for _ in 1 ... count {
             let label = createLabel()


### PR DESCRIPTION
• allows AEOTPTextField to be pre-configured with semantic content attribute to make it appear in a specific direction

• note that I've enabled language in Test app in order to visually identify the problem
• here is attached 2 images , first with the current issue, custom text field semantic is set in storyboard to be LTR

<img width="200" height="300" alt="issue" src="https://github.com/user-attachments/assets/34abb672-d2e4-495c-a04c-0dca26f37c2b" />

•The second with the resolved one by changing the custom textfield semantic to LTR, and code change for PR

<img width="200" height="300" alt="solve" src="https://github.com/user-attachments/assets/522c2e43-a14b-4ced-9d7f-64c4cfe1513e" />



